### PR TITLE
[FEATURE] 공통 응답 구조 및 기본 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.postgresql:postgresql'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/second/kirby/KirbyApplication.java
+++ b/src/main/java/com/second/kirby/KirbyApplication.java
@@ -2,8 +2,10 @@ package com.second.kirby;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class KirbyApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/second/kirby/config/RestTemplateConfig.java
+++ b/src/main/java/com/second/kirby/config/RestTemplateConfig.java
@@ -1,0 +1,12 @@
+package com.second.kirby.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
+
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/second/kirby/domain/BaseEntity.java
+++ b/src/main/java/com/second/kirby/domain/BaseEntity.java
@@ -1,0 +1,30 @@
+package com.second.kirby.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@Setter
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @CreatedDate
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/second/kirby/dto/DefaultResponseData.java
+++ b/src/main/java/com/second/kirby/dto/DefaultResponseData.java
@@ -1,0 +1,13 @@
+package com.second.kirby.dto;
+
+import lombok.Getter;
+
+@Getter
+public class DefaultResponseData<T> implements ResponseData<T> {
+
+    private final T body;
+
+    protected DefaultResponseData(T body) {
+        this.body = body;
+    }
+}

--- a/src/main/java/com/second/kirby/dto/ResponseData.java
+++ b/src/main/java/com/second/kirby/dto/ResponseData.java
@@ -1,0 +1,5 @@
+package com.second.kirby.dto;
+
+public interface ResponseData<T> {
+    T getBody();
+}

--- a/src/main/java/com/second/kirby/dto/ResponseDto.java
+++ b/src/main/java/com/second/kirby/dto/ResponseDto.java
@@ -1,0 +1,31 @@
+package com.second.kirby.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ResponseDto<T> {
+
+    private final LocalDateTime timestamp;
+    private final String message;
+    private final ResponseData<T> data;
+
+    public ResponseDto(LocalDateTime timestamp, String message, ResponseData<T> data) {
+        this.timestamp = timestamp;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> ResponseDto<T> of(String message) {
+        return new ResponseDto<>(LocalDateTime.now(), message, null);
+    }
+
+    public static <T> ResponseDto<T> of(T body) {
+        return new ResponseDto<>(LocalDateTime.now(), null, new DefaultResponseData<>(body));
+    }
+
+    public static <T> ResponseDto<T> of(T body, String message) {
+        return new ResponseDto<>(LocalDateTime.now(), message, new DefaultResponseData<>(body));
+    }
+}


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #1 
---
### 🚀 어떤 기능을 구현했나요?
- API 응답 형식을 통일하기 위한 공통 응답 DTO(ResponseDto) 작성
- 데이터 포맷을 유연하게 구성할 수 있도록 ResponseData 인터페이스 + Default 구현체 설계
- JPA 공통 엔티티(BaseEntity) 도입으로 id/생성일/수정일 자동 관리
- 외부 API 호출을 위한 RestTemplate 설정 클래스 추가
- 스웨거 의존성 추가

### 🔥 어떻게 해결했나요?
- 응답의 일관성을 위한 제네릭 기반 구조 설계
- 확장성을 고려한 인터페이스 구조
- Spring Data JPA의 Auditing 기능 사용하여 자동 시간 필드 부여
- RestTemplate는 Bean으로 등록하여 DI 사용 가능하게 설정

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 응답 구조가 향후 모든 API에 적용 가능한지 확인해주세요.

### 📚 참고 자료, 할 말
- 없습니다.
