### PR TITLE
[FEATURE] 회원 탈퇴 및 프로필 이미지 관리 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ out/
 
 ### .env ###
 .env
+
+### Uploads ###
+/uploads/
+uploads/

--- a/src/main/java/com/second/kirby/config/FileStorageProperties.java
+++ b/src/main/java/com/second/kirby/config/FileStorageProperties.java
@@ -1,0 +1,17 @@
+package com.second.kirby.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "file.storage")
+@Getter
+@Setter
+public class FileStorageProperties {
+
+    private String uploadDir;
+    private String profileImageDir;
+    private long maxFileSize;
+}

--- a/src/main/java/com/second/kirby/config/SecurityConfig.java
+++ b/src/main/java/com/second/kirby/config/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/uploads/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
                         .requestMatchers("/actuator/health").permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/second/kirby/controller/FileController.java
+++ b/src/main/java/com/second/kirby/controller/FileController.java
@@ -1,0 +1,46 @@
+package com.second.kirby.controller;
+
+import com.second.kirby.service.FileStorageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "파일", description = "파일 조회 API")
+@RestController
+@RequestMapping("/api/uploads")
+@RequiredArgsConstructor
+public class FileController {
+
+    private final FileStorageService fileStorageService;
+
+    @Operation(summary = "프로필 이미지 조회", description = "저장된 프로필 이미지를 조회합니다.")
+    @GetMapping("/profiles/{filename:.+}")
+    public ResponseEntity<Resource> getProfileImage(@PathVariable String filename) {
+        Resource resource = fileStorageService.loadProfileImage(filename);
+
+        String contentType = determineContentType(filename);
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(contentType))
+                .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + filename + "\"")
+                .body(resource);
+    }
+
+    private String determineContentType(String filename) {
+        String extension = filename.substring(filename.lastIndexOf(".") + 1).toLowerCase();
+        return switch (extension) {
+            case "jpg", "jpeg" -> "image/jpeg";
+            case "png" -> "image/png";
+            case "gif" -> "image/gif";
+            default -> "application/octet-stream";
+        };
+    }
+}

--- a/src/main/java/com/second/kirby/controller/UserController.java
+++ b/src/main/java/com/second/kirby/controller/UserController.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "사용자", description = "사용자 정보 API")
 @RestController
@@ -34,7 +35,8 @@ public class UserController {
                 user.getUsername(),
                 user.getName(),
                 user.getEmail(),
-                user.getPhoneNumber()
+                user.getPhoneNumber(),
+                user.getProfileImageUrl()
         );
 
         return ResponseEntity.ok(ResponseDto.success(userInfo, "사용자 정보 조회 성공"));
@@ -66,6 +68,31 @@ public class UserController {
         return ResponseEntity.ok(ResponseDto.success("비밀번호가 변경되었습니다."));
     }
 
+    @Operation(summary = "프로필 이미지 변경", description = "사용자의 프로필 이미지를 변경합니다.")
+    @SecurityRequirement(name = "bearerAuth")
+    @PostMapping("/profile/image")
+    public ResponseEntity<ResponseDto<ProfileImageResponse>> updateProfileImage(
+            Authentication authentication,
+            @RequestParam("image") MultipartFile file) {
+
+        User user = userService.findByUsername(authentication.getName());
+        String filename = userService.updateProfileImage(user.getId(), file);
+
+        ProfileImageResponse response = new ProfileImageResponse(filename);
+        return ResponseEntity.ok(ResponseDto.success(response, "프로필 이미지가 변경되었습니다."));
+    }
+
+    @Operation(summary = "프로필 이미지 삭제", description = "사용자의 프로필 이미지를 삭제합니다.")
+    @SecurityRequirement(name = "bearerAuth")
+    @DeleteMapping("/profile/image")
+    public ResponseEntity<ResponseDto<Void>> deleteProfileImage(Authentication authentication) {
+
+        User user = userService.findByUsername(authentication.getName());
+        userService.deleteProfileImage(user.getId());
+
+        return ResponseEntity.ok(ResponseDto.success("프로필 이미지가 삭제되었습니다."));
+    }
+
     @Operation(summary = "회원 탈퇴", description = "현재 비밀번호 확인 후 모든 개인 데이터를 삭제하고 회원 탈퇴합니다.")
     @SecurityRequirement(name = "bearerAuth")
     @DeleteMapping("/me")
@@ -85,7 +112,14 @@ public class UserController {
             String username,
             String name,
             String email,
-            String phoneNumber
+            String phoneNumber,
+            String profileImageUrl
+    ) {
+    }
+
+    // 프로필 이미지 응답 DTO
+    public record ProfileImageResponse(
+            String filename
     ) {
     }
 }

--- a/src/main/java/com/second/kirby/controller/UserController.java
+++ b/src/main/java/com/second/kirby/controller/UserController.java
@@ -2,12 +2,10 @@ package com.second.kirby.controller;
 
 import com.second.kirby.domain.User;
 import com.second.kirby.dto.ResponseDto;
+import com.second.kirby.dto.request.user.DeleteAccountRequest;
 import com.second.kirby.dto.request.user.PasswordChangeRequest;
 import com.second.kirby.dto.request.user.ProfileUpdateRequest;
-import com.second.kirby.exception.BusinessException;
-import com.second.kirby.exception.ResponseCode;
 import com.second.kirby.service.UserService;
-import com.second.kirby.util.JwtUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -24,7 +22,6 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
-    private final JwtUtil jwtUtil;
 
     @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자의 정보를 조회합니다.")
     @SecurityRequirement(name = "bearerAuth")
@@ -47,13 +44,11 @@ public class UserController {
     @SecurityRequirement(name = "bearerAuth")
     @PutMapping("/profile")
     public ResponseEntity<ResponseDto<Void>> updateProfile(
-            @RequestHeader("Authorization") String authorizationHeader,
+            Authentication authentication,
             @Valid @RequestBody ProfileUpdateRequest request) {
 
-        String accessToken = extractTokenFromHeader(authorizationHeader);
-        Long userId = jwtUtil.getUserId(accessToken);
-
-        userService.updateProfile(userId, request);
+        User user = userService.findByUsername(authentication.getName());
+        userService.updateProfile(user.getId(), request);
 
         return ResponseEntity.ok(ResponseDto.success("프로필 정보가 변경되었습니다."));
     }
@@ -62,23 +57,26 @@ public class UserController {
     @SecurityRequirement(name = "bearerAuth")
     @PutMapping("/password")
     public ResponseEntity<ResponseDto<Void>> changePassword(
-            @RequestHeader("Authorization") String authorizationHeader,
+            Authentication authentication,
             @Valid @RequestBody PasswordChangeRequest request) {
 
-        String accessToken = extractTokenFromHeader(authorizationHeader);
-        Long userId = jwtUtil.getUserId(accessToken);
-
-        userService.changePassword(userId, request);
+        User user = userService.findByUsername(authentication.getName());
+        userService.changePassword(user.getId(), request);
 
         return ResponseEntity.ok(ResponseDto.success("비밀번호가 변경되었습니다."));
     }
 
-    // Bearer 토큰 추출 헬퍼 메서드
-    private String extractTokenFromHeader(String authorizationHeader) {
-        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
-            throw new BusinessException(ResponseCode.UNAUTHORIZED, "액세스 토큰이 필요합니다");
-        }
-        return authorizationHeader.substring(7);
+    @Operation(summary = "회원 탈퇴", description = "현재 비밀번호 확인 후 모든 개인 데이터를 삭제하고 회원 탈퇴합니다.")
+    @SecurityRequirement(name = "bearerAuth")
+    @DeleteMapping("/me")
+    public ResponseEntity<ResponseDto<Void>> deleteAccount(
+            Authentication authentication,
+            @Valid @RequestBody DeleteAccountRequest request) {
+
+        User user = userService.findByUsername(authentication.getName());
+        userService.deleteAccount(user.getId(), request);
+
+        return ResponseEntity.ok(ResponseDto.success("회원 탈퇴가 완료되었습니다."));
     }
 
     // 사용자 정보 응답 DTO

--- a/src/main/java/com/second/kirby/domain/User.java
+++ b/src/main/java/com/second/kirby/domain/User.java
@@ -34,6 +34,9 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String password;
 
+    @Column(name = "profile_image_url")
+    private String profileImageUrl;
+
     @Column(name = "last_login_at")
     private LocalDateTime lastLoginAt;
 

--- a/src/main/java/com/second/kirby/dto/request/user/DeleteAccountRequest.java
+++ b/src/main/java/com/second/kirby/dto/request/user/DeleteAccountRequest.java
@@ -1,0 +1,12 @@
+package com.second.kirby.dto.request.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "회원 탈퇴 요청")
+public record DeleteAccountRequest(
+        @Schema(description = "현재 비밀번호", example = "password123!")
+        @NotBlank(message = "비밀번호를 입력해주세요")
+        String password
+) {
+}

--- a/src/main/java/com/second/kirby/repository/BallCollectionRepository.java
+++ b/src/main/java/com/second/kirby/repository/BallCollectionRepository.java
@@ -7,4 +7,7 @@ import java.util.Optional;
 
 public interface BallCollectionRepository extends JpaRepository<BallCollection, Long> {
     Optional<BallCollection> findByUserIdAndStatus(Long userId, BallCollection.Status status);
+
+    // 특정 사용자의 모든 공 수거 기록 삭제
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/second/kirby/repository/RecurringScheduleRepository.java
+++ b/src/main/java/com/second/kirby/repository/RecurringScheduleRepository.java
@@ -18,4 +18,7 @@ public interface RecurringScheduleRepository extends JpaRepository<RecurringSche
 
     // 존재 여부 확인
     boolean existsByIdAndUserId(Long id, Long userId);
+
+    // 특정 사용자의 모든 반복 일정 삭제
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/second/kirby/repository/RobotSessionRepository.java
+++ b/src/main/java/com/second/kirby/repository/RobotSessionRepository.java
@@ -22,4 +22,6 @@ public interface RobotSessionRepository extends JpaRepository<RobotSession, Long
     // 만료된 세션들 조회
     @Query("SELECT rs FROM RobotSession rs WHERE rs.lastHeartbeat < :expireTime AND rs.connectedUserId IS NOT NULL")
     List<RobotSession> findExpiredSessions(LocalDateTime expireTime);
+
+
 }

--- a/src/main/java/com/second/kirby/repository/ScheduleRepository.java
+++ b/src/main/java/com/second/kirby/repository/ScheduleRepository.java
@@ -47,4 +47,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     // 사용자의 특정 일정 존재 여부 확인
     boolean existsByIdAndUserId(Long id, Long userId);
+
+    // 특정 사용자의 모든 일정 삭제
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/second/kirby/repository/TrainingRepository.java
+++ b/src/main/java/com/second/kirby/repository/TrainingRepository.java
@@ -13,4 +13,7 @@ public interface TrainingRepository extends JpaRepository<Training, Long> {
     // 특정 사용자의 진행중인 훈련 조회
     Optional<Training> findByUserIdAndStatusIn(Long userId, List<Training.TrainingStatus> statuses);
 
+    // 특정 사용자의 모든 훈련 기록 삭제
+    void deleteByUserId(Long userId);
+
 }

--- a/src/main/java/com/second/kirby/service/FileStorageService.java
+++ b/src/main/java/com/second/kirby/service/FileStorageService.java
@@ -1,0 +1,164 @@
+package com.second.kirby.service;
+
+import com.second.kirby.config.FileStorageProperties;
+import com.second.kirby.exception.BusinessException;
+import com.second.kirby.exception.ResponseCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FileStorageService {
+
+    private final FileStorageProperties fileStorageProperties;
+
+    private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList("jpg", "jpeg", "png", "gif");
+    private static final long MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
+    /**
+     * 프로필 이미지를 저장하고 저장된 파일명을 반환합니다.
+     *
+     * @param file 업로드할 이미지 파일
+     * @return 저장된 파일명
+     */
+    public String storeProfileImage(MultipartFile file) {
+        validateFile(file);
+
+        String originalFilename = StringUtils.cleanPath(file.getOriginalFilename());
+        String fileExtension = getFileExtension(originalFilename);
+        String storedFilename = generateUniqueFilename(fileExtension);
+
+        try {
+            Path uploadPath = getProfileImagePath();
+            Files.createDirectories(uploadPath);
+
+            Path targetLocation = uploadPath.resolve(storedFilename);
+            Files.copy(file.getInputStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING);
+
+            log.info("프로필 이미지 저장 완료: {}", storedFilename);
+            return storedFilename;
+
+        } catch (IOException e) {
+            log.error("파일 저장 실패: {}", originalFilename, e);
+            throw new BusinessException(ResponseCode.INTERNAL_SERVER_ERROR, "파일 저장에 실패했습니다.");
+        }
+    }
+
+    /**
+     * 프로필 이미지 파일을 삭제합니다.
+     *
+     * @param filename 삭제할 파일명
+     */
+    public void deleteProfileImage(String filename) {
+        if (filename == null || filename.isEmpty()) {
+            return;
+        }
+
+        try {
+            Path filePath = getProfileImagePath().resolve(filename).normalize();
+            Files.deleteIfExists(filePath);
+            log.info("프로필 이미지 삭제 완료: {}", filename);
+        } catch (IOException e) {
+            log.error("파일 삭제 실패: {}", filename, e);
+            // 파일 삭제 실패는 치명적이지 않으므로 예외를 던지지 않음
+        }
+    }
+
+    /**
+     * 프로필 이미지 파일을 로드합니다.
+     *
+     * @param filename 로드할 파일명
+     * @return 파일 리소스
+     */
+    public Resource loadProfileImage(String filename) {
+        try {
+            Path filePath = getProfileImagePath().resolve(filename).normalize();
+            Resource resource = new UrlResource(filePath.toUri());
+
+            if (resource.exists() && resource.isReadable()) {
+                return resource;
+            } else {
+                throw new BusinessException(ResponseCode.BAD_REQUEST, "파일을 찾을 수 없습니다.");
+            }
+        } catch (Exception e) {
+            log.error("파일 로드 실패: {}", filename, e);
+            throw new BusinessException(ResponseCode.BAD_REQUEST, "파일을 로드할 수 없습니다.");
+        }
+    }
+
+    /**
+     * 프로필 이미지 저장 경로를 반환합니다.
+     */
+    private Path getProfileImagePath() {
+        String uploadDir = fileStorageProperties.getUploadDir();
+        String profileDir = fileStorageProperties.getProfileImageDir();
+        return Paths.get(uploadDir, profileDir).toAbsolutePath().normalize();
+    }
+
+    /**
+     * UUID를 사용하여 고유한 파일명을 생성합니다.
+     */
+    private String generateUniqueFilename(String extension) {
+        return UUID.randomUUID().toString() + "." + extension;
+    }
+
+    /**
+     * 파일 확장자를 추출합니다.
+     */
+    private String getFileExtension(String filename) {
+        int lastIndexOf = filename.lastIndexOf(".");
+        if (lastIndexOf == -1) {
+            throw new BusinessException(ResponseCode.INVALID_INPUT_VALUE, "파일 확장자가 없습니다.");
+        }
+        return filename.substring(lastIndexOf + 1).toLowerCase();
+    }
+
+    /**
+     * 파일 유효성을 검증합니다.
+     */
+    private void validateFile(MultipartFile file) {
+        // 파일이 비어있는지 확인
+        if (file.isEmpty()) {
+            throw new BusinessException(ResponseCode.INVALID_INPUT_VALUE, "파일이 비어있습니다.");
+        }
+
+        // 파일 크기 확인
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new BusinessException(ResponseCode.INVALID_INPUT_VALUE,
+                    "파일 크기는 5MB를 초과할 수 없습니다.");
+        }
+
+        // 파일 확장자 확인
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null) {
+            throw new BusinessException(ResponseCode.INVALID_INPUT_VALUE, "파일명이 올바르지 않습니다.");
+        }
+
+        String extension = getFileExtension(originalFilename);
+        if (!ALLOWED_EXTENSIONS.contains(extension)) {
+            throw new BusinessException(ResponseCode.INVALID_INPUT_VALUE,
+                    "지원하지 않는 파일 형식입니다. (jpg, jpeg, png, gif만 가능)");
+        }
+
+        // Content-Type 확인
+        String contentType = file.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new BusinessException(ResponseCode.INVALID_INPUT_VALUE, "이미지 파일만 업로드 가능합니다.");
+        }
+    }
+}

--- a/src/main/java/com/second/kirby/service/UserService.java
+++ b/src/main/java/com/second/kirby/service/UserService.java
@@ -27,6 +27,7 @@ public class UserService {
     private final TrainingRepository trainingRepository;
     private final BallCollectionRepository ballCollectionRepository;
     private final RobotSessionRepository robotSessionRepository;
+    private final FileStorageService fileStorageService;
 
     // ========== 사용자 조회 ==========
 
@@ -109,6 +110,11 @@ public class UserService {
             throw new BusinessException(ResponseCode.INVALID_PASSWORD);
         }
 
+        // 프로필 이미지 삭제
+        if (user.getProfileImageUrl() != null) {
+            fileStorageService.deleteProfileImage(user.getProfileImageUrl());
+        }
+
         // 연관 데이터 삭제
         deleteUserRelatedData(userId);
 
@@ -145,5 +151,49 @@ public class UserService {
         // 공 수거 기록 삭제
         ballCollectionRepository.deleteByUserId(userId);
         log.info("공 수거 기록 삭제 완료: userId={}", userId);
+    }
+
+    // ========== 프로필 이미지 변경 ==========
+
+    @Transactional
+    public String updateProfileImage(Long userId, org.springframework.web.multipart.MultipartFile file) {
+        log.info("프로필 이미지 변경 요청: userId={}", userId);
+
+        User user = findById(userId);
+
+        // 기존 이미지가 있다면 삭제
+        if (user.getProfileImageUrl() != null) {
+            fileStorageService.deleteProfileImage(user.getProfileImageUrl());
+        }
+
+        // 새 이미지 저장
+        String filename = fileStorageService.storeProfileImage(file);
+
+        // 사용자 정보 업데이트
+        user.setProfileImageUrl(filename);
+        userRepository.save(user);
+
+        log.info("프로필 이미지 변경 완료: userId={}, filename={}", userId, filename);
+        return filename;
+    }
+
+    @Transactional
+    public void deleteProfileImage(Long userId) {
+        log.info("프로필 이미지 삭제 요청: userId={}", userId);
+
+        User user = findById(userId);
+
+        if (user.getProfileImageUrl() == null) {
+            throw new BusinessException(ResponseCode.BAD_REQUEST, "삭제할 프로필 이미지가 없습니다.");
+        }
+
+        // 이미지 파일 삭제
+        fileStorageService.deleteProfileImage(user.getProfileImageUrl());
+
+        // 사용자 정보 업데이트
+        user.setProfileImageUrl(null);
+        userRepository.save(user);
+
+        log.info("프로필 이미지 삭제 완료: userId={}", userId);
     }
 }

--- a/src/main/java/com/second/kirby/service/UserService.java
+++ b/src/main/java/com/second/kirby/service/UserService.java
@@ -1,11 +1,13 @@
 package com.second.kirby.service;
 
+import com.second.kirby.domain.RobotSession;
 import com.second.kirby.domain.User;
+import com.second.kirby.dto.request.user.DeleteAccountRequest;
 import com.second.kirby.dto.request.user.PasswordChangeRequest;
 import com.second.kirby.dto.request.user.ProfileUpdateRequest;
 import com.second.kirby.exception.BusinessException;
 import com.second.kirby.exception.ResponseCode;
-import com.second.kirby.repository.UserRepository;
+import com.second.kirby.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -20,6 +22,11 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final ScheduleRepository scheduleRepository;
+    private final RecurringScheduleRepository recurringScheduleRepository;
+    private final TrainingRepository trainingRepository;
+    private final BallCollectionRepository ballCollectionRepository;
+    private final RobotSessionRepository robotSessionRepository;
 
     // ========== 사용자 조회 ==========
 
@@ -87,5 +94,56 @@ public class UserService {
         userRepository.save(user);
 
         log.info("비밀번호 변경 완료: userId={}", userId);
+    }
+
+    // ========== 회원 탈퇴 ==========
+
+    @Transactional
+    public void deleteAccount(Long userId, DeleteAccountRequest request) {
+        log.info("회원 탈퇴 요청: userId={}", userId);
+
+        User user = findById(userId);
+
+        // 비밀번호 확인
+        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new BusinessException(ResponseCode.INVALID_PASSWORD);
+        }
+
+        // 연관 데이터 삭제
+        deleteUserRelatedData(userId);
+
+        // 사용자 삭제
+        userRepository.delete(user);
+
+        log.info("회원 탈퇴 완료: userId={}, username={}", userId, user.getUsername());
+    }
+
+    // ========== 연관 데이터 삭제 ==========
+
+    private void deleteUserRelatedData(Long userId) {
+        log.info("사용자 연관 데이터 삭제 시작: userId={}", userId);
+
+        // 로봇 세션 연결 해제
+        robotSessionRepository.findByConnectedUserId(userId).ifPresent(session -> {
+            log.info("로봇 세션 연결 해제: sessionId={}", session.getId());
+            session.disconnect();
+            robotSessionRepository.save(session);
+        });
+
+        // 일정 삭제
+        scheduleRepository.deleteByUserId(userId);
+        log.info("일정 삭제 완료: userId={}", userId);
+
+        // 반복 일정 삭제
+        recurringScheduleRepository.deleteByUserId(userId);
+        log.info("반복 일정 삭제 완료: userId={}", userId);
+
+        // 훈련 기록 삭제
+        trainingRepository.deleteByUserId(userId);
+        log.info("훈련 기록 삭제 완료: userId={}", userId);
+
+        // 공 수거 기록 삭제
+        ballCollectionRepository.deleteByUserId(userId);
+        log.info("공 수거 기록 삭제 완료: userId={}", userId);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,11 @@ spring:
       hibernate:
         format_sql: true
     show-sql: true
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 5MB
+      max-request-size: 5MB
 
 jwt:
   secret: ${JWT_SECRET}
@@ -33,3 +38,9 @@ logging:
   level:
     org.hibernate.SQL: WARN
     org.springframework.scheduling: WARN
+
+file:
+  storage:
+    upload-dir: ./uploads
+    profile-image-dir: profiles
+    max-file-size: 5242880


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #17 
---
### 📌 요약
- 회원 탈퇴 기능과 프로필 이미지 관리 기능을 구현했습니다.

### ✅ 작업 내용
- 1️⃣ 회원 탈퇴 기능
  - 비밀번호 확인 후 회원 탈퇴 API 구현
  - 사용자 연관 데이터 자동 삭제 (일정, 반복 일정, 훈련, 공 수거, 로봇 세션)
  - 프로필 이미지 파일 자동 삭제

- 2️⃣ 프로필 이미지 관리 기능
  - 프로필 이미지 업로드/삭제/조회 API 구현
  - 로컬 파일 시스템 기반 저장
  - UUID 파일명으로 보안 강화
  - 파일 타입 및 크기 검증 (jpg/jpeg/png/gif, 5MB 이하)

### 📚 참고 자료, 할 말
- 파일 저장 경로: `./uploads/profiles/`
- 최대 파일 크기: 5MB
- 지원 형식: jpg, jpeg, png, gif
